### PR TITLE
Fixes broken type definition.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -732,9 +732,9 @@ function sizeof(fields: CoderType<any>[]): Option<number> {
   return size;
 }
 
-export function struct<
-  T extends Record<string, any>
->(fields: StructRecord<T>): CoderType<StructInput<T>> {
+export function struct<T extends Record<string, any>>(
+  fields: StructRecord<T>
+): CoderType<StructInput<T>> {
   if (Array.isArray(fields)) throw new Error('Packed.Struct: got array instead of object');
   return wrap({
     size: sizeof(Object.values(fields)),

--- a/index.ts
+++ b/index.ts
@@ -732,7 +732,7 @@ function sizeof(fields: CoderType<any>[]): Option<number> {
   return size;
 }
 
-export function struct<T>(fields: StructRecord<T>): CoderType<StructInput<T>> {
+export function struct<T extends Record<string, any>>(fields: StructRecord<T>): CoderType<StructInput<T>> {
   if (Array.isArray(fields)) throw new Error('Packed.Struct: got array instead of object');
   return wrap({
     size: sizeof(Object.values(fields)),

--- a/index.ts
+++ b/index.ts
@@ -732,7 +732,9 @@ function sizeof(fields: CoderType<any>[]): Option<number> {
   return size;
 }
 
-export function struct<T extends Record<string, any>>(fields: StructRecord<T>): CoderType<StructInput<T>> {
+export function struct<
+  T extends Record<string, any>
+>(fields: StructRecord<T>): CoderType<StructInput<T>> {
   if (Array.isArray(fields)) throw new Error('Packed.Struct: got array instead of object');
   return wrap({
     size: sizeof(Object.values(fields)),


### PR DESCRIPTION
I'm not sure why the compiler isn't complaining about this (perhaps bug in the version of TS being used), but `StructRecord` requires a generic parameter assignable to `Record<string, any>`, and an unconstrained `T` doesn't meet that requirement.